### PR TITLE
Fix wheel canvas resizing, add IndexedDB save button, and enable data import

### DIFF
--- a/PwaTest/Pages/Wheel.razor
+++ b/PwaTest/Pages/Wheel.razor
@@ -3,8 +3,10 @@
 @using System.Text.Json.Serialization
 @using System.Linq
 @using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
-@implements IDisposable
+@using ExcelDataReader
+@using System.Text
 
 <PageTitle>Wheel of Luck</PageTitle>
 
@@ -22,7 +24,10 @@
             <button class="btn btn-success" @onclick="Spin">Spin</button>
             <button class="btn btn-secondary" @onclick="SaveCurrentStudents">Save</button>
             <div class="btn-group">
-                <button class="btn btn-info" @onclick="ImportFromFile">Import</button>
+                <label class="btn btn-info mb-0">
+                    Import
+                    <InputFile OnChange="HandleFileSelected" accept=".csv,.xlsx,.xls" class="d-none" />
+                </label>
                 <button type="button" class="btn btn-info dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
                     <span class="visually-hidden">Toggle Dropdown</span>
                 </button>
@@ -112,7 +117,6 @@
     private string? winner;
     private string? saveLabel;
     private List<SavedSet> savedSets = new();
-    private DotNetObjectReference<Wheel>? objRef;
 
     private RenderFragment SavedSetsSection => @<div>
         <h5>Saved Sets</h5>
@@ -227,19 +231,50 @@
         await JS.InvokeVoidAsync("wheel.downloadExcelTemplate");
     }
 
-    private async Task ImportFromFile()
+    private async Task HandleFileSelected(InputFileChangeEventArgs e)
     {
-        objRef ??= DotNetObjectReference.Create(this);
-        await JS.InvokeVoidAsync("wheel.importFile", objRef);
-    }
+        var file = e.File;
+        using var stream = file.OpenReadStream(4 * 1024 * 1024);
+        var names = new List<string>();
 
-    [JSInvokable]
-    public async Task ReceiveImported(string[] names)
-    {
-        students = names.ToList();
-        winner = null;
-        await JS.InvokeVoidAsync("wheel.draw", students, true);
-        StateHasChanged();
+        if (file.Name.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+        {
+            using var reader = new StreamReader(stream);
+            while (!reader.EndOfStream)
+            {
+                var line = await reader.ReadLineAsync();
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var name = line.Trim();
+                if (string.Equals(name, "name", StringComparison.OrdinalIgnoreCase)) continue;
+                names.Add(name);
+            }
+        }
+        else
+        {
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            ms.Position = 0;
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            using var reader = ExcelReaderFactory.CreateReader(ms);
+            do
+            {
+                while (reader.Read())
+                {
+                    var value = reader.GetValue(0)?.ToString();
+                    if (string.IsNullOrWhiteSpace(value)) continue;
+                    if (string.Equals(value.Trim(), "name", StringComparison.OrdinalIgnoreCase)) continue;
+                    names.Add(value.Trim());
+                }
+            } while (reader.NextResult());
+        }
+
+        if (names.Count > 0)
+        {
+            students = names;
+            winner = null;
+            await JS.InvokeVoidAsync("wheel.draw", students, true);
+            StateHasChanged();
+        }
     }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
@@ -279,11 +314,6 @@
         winner = null;
         await JS.InvokeVoidAsync("wheel.draw", students, true);
         StateHasChanged();
-    }
-
-    public void Dispose()
-    {
-        objRef?.Dispose();
     }
 
     private class SavedSet

--- a/PwaTest/Pages/Wheel.razor
+++ b/PwaTest/Pages/Wheel.razor
@@ -127,7 +127,10 @@
                 {
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         @set.Label
-                        <button class="btn btn-sm btn-primary" @onclick="() => LoadSavedSet(set)">Load</button>
+                        <div class="d-flex align-items-center gap-2">
+                            <button class="btn btn-sm btn-primary" @onclick="() => LoadSavedSet(set)">Load</button>
+                            <button type="button" class="btn-close" aria-label="Remove" @onclick="() => DeleteSavedSet(set.Id)"></button>
+                        </div>
                     </li>
                 }
             </ul>
@@ -316,8 +319,15 @@
         StateHasChanged();
     }
 
+    private async Task DeleteSavedSet(long id)
+    {
+        await JS.InvokeVoidAsync("wheel.deleteHistory", id);
+        await LoadHistory();
+    }
+
     private class SavedSet
     {
+        [JsonPropertyName("id")] public long Id { get; set; }
         [JsonPropertyName("label")] public string Label { get; set; } = string.Empty;
         [JsonPropertyName("names")] public List<string> Names { get; set; } = new();
     }

--- a/PwaTest/Pages/Wheel.razor
+++ b/PwaTest/Pages/Wheel.razor
@@ -1,5 +1,10 @@
 
 @page "/"
+@using System.Text.Json.Serialization
+@using System.Linq
+@using Microsoft.AspNetCore.Components
+@using Microsoft.JSInterop
+@implements IDisposable
 
 <PageTitle>Wheel of Luck</PageTitle>
 
@@ -13,27 +18,56 @@
 <div class="d-flex flex-column flex-md-row mt-3 align-items-start">
     <div class="d-flex flex-column align-items-center flex-shrink-0">
         <canvas id="wheelCanvas" width="600" height="600"></canvas>
-        <button class="btn btn-success mt-3" @onclick="Spin">Spin</button>
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-success" @onclick="Spin">Spin</button>
+            <button class="btn btn-secondary" @onclick="SaveCurrentStudents">Save</button>
+            <div class="btn-group">
+                <button class="btn btn-info" @onclick="ImportFromFile">Import</button>
+                <button type="button" class="btn btn-info dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                    <span class="visually-hidden">Toggle Dropdown</span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><button class="dropdown-item" @onclick="DownloadCsvTemplate">CSV Template</button></li>
+                    <li><button class="dropdown-item" @onclick="DownloadExcelTemplate">Excel Template</button></li>
+                </ul>
+            </div>
+        </div>
 
         @if (!string.IsNullOrEmpty(winner))
         {
             <p class="mt-3"><strong>Winner: @winner</strong></p>
         }
+
+        <div class="mt-4 w-100 d-none d-md-block">
+            @SavedSetsSection
+        </div>
     </div>
 
-    @if (students.Count > 0)
-    {
-        <ul class="list-group ms-md-3 mt-3 mt-md-0 w-100">
-            @for (int i = 0; i < students.Count; i++)
-            {
-                var index = i;
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                    @students[index]
-                    <button type="button" class="btn-close" aria-label="Remove" @onclick="() => RemoveStudent(index)"></button>
-                </li>
-            }
-        </ul>
-    }
+    <div class="ms-md-3 mt-3 mt-md-0 w-100">
+        <h5>Added Items</h5>
+        @if (students.Count > 0)
+        {
+            <ul class="list-group">
+                @for (int i = 0; i < students.Count; i++)
+                {
+                    var index = i;
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        @students[index]
+                        <button type="button" class="btn-close" aria-label="Remove" @onclick="() => RemoveStudent(index)"></button>
+                    </li>
+                }
+            </ul>
+            <button class="btn btn-sm btn-outline-danger mt-2" @onclick="ClearAll">Clear All</button>
+        }
+        else
+        {
+            <p class="text-muted">No items added yet.</p>
+        }
+
+        <div class="mt-4 w-100 d-block d-md-none">
+            @SavedSetsSection
+        </div>
+    </div>
 </div>
 
 <div class="modal fade" id="winnerModal" tabindex="-1" aria-labelledby="winnerModalLabel" aria-hidden="true">
@@ -54,10 +88,51 @@
     </div>
 </div>
 
+<div class="modal fade" id="saveModal" tabindex="-1" aria-labelledby="saveModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="saveModalLabel">Save Current Set</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input class="form-control" @bind="saveLabel" placeholder="Set name" />
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" @onclick="ConfirmSave">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 @code {
     private string? newStudent;
-    private List<string> students = new();
+    private List<string> students = new() { "Item 1", "Item 2", "Item 3", "Item 4" };
     private string? winner;
+    private string? saveLabel;
+    private List<SavedSet> savedSets = new();
+    private DotNetObjectReference<Wheel>? objRef;
+
+    private RenderFragment SavedSetsSection => @<div>
+        <h5>Saved Sets</h5>
+        @if (savedSets.Count > 0)
+        {
+            <ul class="list-group">
+                @foreach (var set in savedSets)
+                {
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        @set.Label
+                        <button class="btn btn-sm btn-primary" @onclick="() => LoadSavedSet(set)">Load</button>
+                    </li>
+                }
+            </ul>
+        }
+        else
+        {
+            <p class="text-muted">No sets saved yet.</p>
+        }
+    </div>;
 
     [Inject] private IJSRuntime JS { get; set; } = default!;
 
@@ -66,6 +141,7 @@
         if (firstRender)
         {
             await JS.InvokeVoidAsync("wheel.draw", students, true);
+            await LoadHistory();
         }
     }
 
@@ -92,6 +168,19 @@
         }
     }
 
+    private async Task ClearAll()
+    {
+        if (students.Count == 0)
+        {
+            return;
+        }
+
+        students.Clear();
+        winner = null;
+        await JS.InvokeVoidAsync("wheel.draw", students, true);
+        StateHasChanged();
+    }
+
     private async Task Spin()
     {
         if (students.Count == 0)
@@ -102,6 +191,55 @@
         winner = await JS.InvokeAsync<string>("wheel.spin", students);
         StateHasChanged();
         await JS.InvokeVoidAsync("wheel.showWinnerModal");
+    }
+
+    private async Task SaveCurrentStudents()
+    {
+        if (students.Count == 0)
+        {
+            return;
+        }
+
+        saveLabel = string.Empty;
+        await JS.InvokeVoidAsync("wheel.showSaveModal");
+    }
+
+    private async Task ConfirmSave()
+    {
+        if (string.IsNullOrWhiteSpace(saveLabel))
+        {
+            return;
+        }
+
+        await JS.InvokeVoidAsync("wheel.saveHistory", students, saveLabel);
+        await LoadHistory();
+        await JS.InvokeVoidAsync("wheel.hideSaveModal");
+        saveLabel = string.Empty;
+    }
+
+    private async Task DownloadCsvTemplate()
+    {
+        await JS.InvokeVoidAsync("wheel.downloadCsvTemplate");
+    }
+
+    private async Task DownloadExcelTemplate()
+    {
+        await JS.InvokeVoidAsync("wheel.downloadExcelTemplate");
+    }
+
+    private async Task ImportFromFile()
+    {
+        objRef ??= DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("wheel.importFile", objRef);
+    }
+
+    [JSInvokable]
+    public async Task ReceiveImported(string[] names)
+    {
+        students = names.ToList();
+        winner = null;
+        await JS.InvokeVoidAsync("wheel.draw", students, true);
+        StateHasChanged();
     }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
@@ -126,5 +264,31 @@
         }
 
         await JS.InvokeVoidAsync("wheel.hideWinnerModal");
+    }
+
+    private async Task LoadHistory()
+    {
+        var history = await JS.InvokeAsync<SavedSet[]>("wheel.getHistory");
+        savedSets = history?.ToList() ?? new();
+        StateHasChanged();
+    }
+
+    private async Task LoadSavedSet(SavedSet set)
+    {
+        students = new List<string>(set.Names);
+        winner = null;
+        await JS.InvokeVoidAsync("wheel.draw", students, true);
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        objRef?.Dispose();
+    }
+
+    private class SavedSet
+    {
+        [JsonPropertyName("label")] public string Label { get; set; } = string.Empty;
+        [JsonPropertyName("names")] public List<string> Names { get; set; } = new();
     }
 }

--- a/PwaTest/PwaTest.csproj
+++ b/PwaTest/PwaTest.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.6" PrivateAssets="all" />
+    <PackageReference Include="ExcelDataReader" Version="3.6.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PwaTest/wwwroot/index.html
+++ b/PwaTest/wwwroot/index.html
@@ -31,6 +31,7 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <script src="js/wheel.js"></script>
     <script>navigator.serviceWorker.register('service-worker.js');</script>
 </body>

--- a/PwaTest/wwwroot/js/wheel.js
+++ b/PwaTest/wwwroot/js/wheel.js
@@ -142,42 +142,6 @@ window.wheel = (function () {
         });
     }
 
-    function importFile(dotNetHelper) {
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = '.csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel';
-        input.onchange = e => {
-            const file = e.target.files[0];
-            if (!file) return;
-            const reader = new FileReader();
-            reader.onload = ev => {
-                let names = [];
-                if (file.name.toLowerCase().endsWith('.csv')) {
-                    const text = ev.target.result;
-                    names = text.split(/\r?\n/).map(l => l.trim()).filter(l => l);
-                } else if (typeof XLSX !== 'undefined') {
-                    const data = new Uint8Array(ev.target.result);
-                    const workbook = XLSX.read(data, { type: 'array' });
-                    const sheet = workbook.Sheets[workbook.SheetNames[0]];
-                    const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
-                    names = rows.map(r => r[0]).filter(Boolean);
-                }
-
-                if (names.length && names[0].toLowerCase() === 'name') {
-                    names.shift();
-                }
-
-                dotNetHelper.invokeMethodAsync('ReceiveImported', names);
-                input.remove();
-            };
-            if (file.name.toLowerCase().endsWith('.csv')) {
-                reader.readAsText(file);
-            } else {
-                reader.readAsArrayBuffer(file);
-            }
-        };
-        input.click();
-    }
 
     function downloadCsvTemplate() {
         const content = ['Name', 'Item 1', 'Item 2', 'Item 3', 'Item 4'].join('\n');
@@ -213,5 +177,5 @@ window.wheel = (function () {
 
     window.addEventListener('resize', () => draw());
 
-    return { draw, spin, showWinnerModal, hideWinnerModal, showSaveModal, hideSaveModal, saveHistory, getHistory, importFile, downloadCsvTemplate, downloadExcelTemplate };
+    return { draw, spin, showWinnerModal, hideWinnerModal, showSaveModal, hideSaveModal, saveHistory, getHistory, downloadCsvTemplate, downloadExcelTemplate };
 })();

--- a/PwaTest/wwwroot/js/wheel.js
+++ b/PwaTest/wwwroot/js/wheel.js
@@ -162,6 +162,11 @@ window.wheel = (function () {
                     const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
                     names = rows.map(r => r[0]).filter(Boolean);
                 }
+
+                if (names.length && names[0].toLowerCase() === 'name') {
+                    names.shift();
+                }
+
                 dotNetHelper.invokeMethodAsync('ReceiveImported', names);
                 input.remove();
             };

--- a/PwaTest/wwwroot/js/wheel.js
+++ b/PwaTest/wwwroot/js/wheel.js
@@ -2,9 +2,10 @@ window.wheel = (function () {
     let angle = 0;
     let currentNames = [];
     let idleId = null;
+    let hasSpun = false;
 
     function startIdle() {
-        if (idleId || !currentNames || currentNames.length === 0) return;
+        if (idleId || !currentNames || currentNames.length === 0 || hasSpun) return;
         function step() {
             angle += 0.002;
             draw();
@@ -74,6 +75,7 @@ window.wheel = (function () {
     function spin(names) {
         if (!names || names.length === 0) return '';
         stopIdle();
+        hasSpun = true;
         return new Promise(resolve => {
             const total = Math.random() * 2 * Math.PI + 10 * 2 * Math.PI;
             const startAngle = angle;
@@ -91,7 +93,6 @@ window.wheel = (function () {
                     const offset = (3 * Math.PI / 2 - (angle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
                     const index = Math.floor(offset / arc);
                     resolve(names[index]);
-                    startIdle();
                 }
             }
             requestAnimationFrame(frame);

--- a/PwaTest/wwwroot/js/wheel.js
+++ b/PwaTest/wwwroot/js/wheel.js
@@ -1,6 +1,26 @@
 window.wheel = (function () {
     let angle = 0;
     let currentNames = [];
+    let idleId = null;
+
+    function startIdle() {
+        if (idleId || !currentNames || currentNames.length === 0) return;
+        function step() {
+            angle += 0.002;
+            draw();
+            if (idleId) {
+                idleId = requestAnimationFrame(step);
+            }
+        }
+        idleId = requestAnimationFrame(step);
+    }
+
+    function stopIdle() {
+        if (idleId) {
+            cancelAnimationFrame(idleId);
+            idleId = null;
+        }
+    }
 
     function draw(names, resetAngle) {
         currentNames = names !== undefined ? names : currentNames;
@@ -17,7 +37,11 @@ window.wheel = (function () {
         canvas.height = size;
         const radius = size / 2;
         ctx.clearRect(0, 0, canvas.width, canvas.height);
-        if (!currentNames || currentNames.length === 0) return;
+        if (!currentNames || currentNames.length === 0) {
+            stopIdle();
+            return;
+        }
+        startIdle();
         const arc = 2 * Math.PI / currentNames.length;
         for (let i = 0; i < currentNames.length; i++) {
             ctx.beginPath();
@@ -49,6 +73,7 @@ window.wheel = (function () {
 
     function spin(names) {
         if (!names || names.length === 0) return '';
+        stopIdle();
         return new Promise(resolve => {
             const total = Math.random() * 2 * Math.PI + 10 * 2 * Math.PI;
             const startAngle = angle;
@@ -66,6 +91,7 @@ window.wheel = (function () {
                     const offset = (3 * Math.PI / 2 - (angle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
                     const index = Math.floor(offset / arc);
                     resolve(names[index]);
+                    startIdle();
                 }
             }
             requestAnimationFrame(frame);


### PR DESCRIPTION
## Summary
- compute wheel size from container width so canvas returns to full size after resizing the window
- show "Added Items" header even when the list is empty
- preload the wheel with four sample items so it isn't empty on start
- add Save button next to Spin that stores current students in IndexedDB for future reuse
- prompt for a name using a custom modal when saving a set of entries so each saved history item is labeled
- list saved sets below the wheel with buttons to load them back onto the wheel
- display saved sets below the Added Items list on mobile screens for improved layout
- add a Clear All button beside "Added Items" to remove every entry from the wheel at once
- add spacing between "Added Items" header and "Clear All" button for visual clarity
- allow importing wheel entries from CSV or Excel files through a new Import button
- move the Clear All button beneath the Added Items list so it matches its original placement
- provide downloadable CSV and Excel templates for importing wheel entries
- generate CSV and Excel templates dynamically in JavaScript instead of storing static files
- remove leftover static Excel import template file

## Testing
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh -c 9.0`
- `~/.dotnet/dotnet build PwaTest.sln`


------
https://chatgpt.com/codex/tasks/task_e_689758f0cdd0832dad7cd5ddab1edb93